### PR TITLE
Fix #8: text visibility issue in sidebar and container on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -293,14 +293,13 @@ input {
   }
 
   .sidebar {
-    width: 100%;
-    padding: 15px;
+    width: 94.5%;
     border-right: none;
     margin-bottom: 20px;
   }
 
   .container {
-    width: 100%;
+    width: 95%;
     padding: 15px;
   }
 


### PR DESCRIPTION
working on issue no #8 
Fix sidebar and container overflow issue on small screens (max-width: 768px)

The sidebar and container elements were previously causing text to be hidden due to overflow settings on small screens. Updated the CSS to increase the width of these elements to 94.5% and 95% respectively, making text more visible and preventing overflow content from being hidden in mobile views.

**before**

![screencapture-127-0-0-1-5501-index-html-2024-11-08-04_06_46](https://github.com/user-attachments/assets/4d210b8a-7f63-4cfa-a289-3759dbba044f)

**after**

![Screenshot 2024-11-08 040755](https://github.com/user-attachments/assets/20f6e397-462c-4a05-9b70-44ca21856b74)
